### PR TITLE
Small cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem "fastlane", '2.162.0'
+gem "xcode-install"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,9 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     word_wrap (1.0.0)
+    xcode-install (2.6.6)
+      claide (>= 0.9.1, < 1.1.0)
+      fastlane (>= 2.1.0, < 3.0.0)
     xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -173,6 +176,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (= 2.162.0)
+  xcode-install
 
 BUNDLED WITH
    1.17.2

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,14 @@
 
 default_platform(:mac)
 
-lane :test do
-  scan(scheme: "sshh")
+platform :mac do
+  before_all do |lane|
+    if FastlaneCore::Helper.mac?
+      xcversion(version: "~> 12.0.0")
+    end
+  end
+
+  lane :test do
+    scan(scheme: "sshh")
+  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,9 +15,10 @@ Install _fastlane_ using
 or alternatively using `brew install fastlane`
 
 # Available Actions
-### test
+## Mac
+### mac test
 ```
-fastlane test
+fastlane mac test
 ```
 
 

--- a/sshh.xcodeproj/project.pbxproj
+++ b/sshh.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21B192B5253235B800461B99 /* QuitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B192B4253235B800461B99 /* QuitButton.swift */; };
+		21B192BA2532360500461B99 /* InputRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B192B92532360500461B99 /* InputRowViewModel.swift */; };
 		462B1AAC2531D85000412268 /* ContentViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462B1AAB2531D85000412268 /* ContentViewViewModel.swift */; };
 		462B1AB82531DA9E00412268 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462B1AB72531DA9E00412268 /* AppState.swift */; };
 		CA5D0147252A39CB0052A2E3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5D0146252A39CB0052A2E3 /* AppDelegate.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		21B192B4253235B800461B99 /* QuitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitButton.swift; sourceTree = "<group>"; };
+		21B192B92532360500461B99 /* InputRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputRowViewModel.swift; sourceTree = "<group>"; };
 		462B1AAB2531D85000412268 /* ContentViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewViewModel.swift; sourceTree = "<group>"; };
 		462B1AB72531DA9E00412268 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		CA5D0143252A39CB0052A2E3 /* sshh.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = sshh.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -91,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				462B1AAB2531D85000412268 /* ContentViewViewModel.swift */,
+				21B192B92532360500461B99 /* InputRowViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -172,6 +177,7 @@
 			children = (
 				CA5D0148252A39CB0052A2E3 /* ContentView.swift */,
 				CA611B1A252CB966004BD126 /* InputRow.swift */,
+				21B192B4253235B800461B99 /* QuitButton.swift */,
 			);
 			path = components;
 			sourceTree = "<group>";
@@ -328,6 +334,8 @@
 				462B1AB82531DA9E00412268 /* AppState.swift in Sources */,
 				CA5D0147252A39CB0052A2E3 /* AppDelegate.swift in Sources */,
 				462B1AAC2531D85000412268 /* ContentViewViewModel.swift in Sources */,
+				21B192BA2532360500461B99 /* InputRowViewModel.swift in Sources */,
+				21B192B5253235B800461B99 /* QuitButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sshh/AppDelegate.swift
+++ b/sshh/AppDelegate.swift
@@ -12,7 +12,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        let contentView = ContentView(vm: appState.contentViewModel)
+        let contentView = ContentView().environmentObject(appState.contentViewModel)
 
         popover.contentSize = NSSize(width: 440, height: 360)
         popover.contentViewController = NSHostingController(rootView: contentView)

--- a/sshh/ViewModels/ContentViewViewModel.swift
+++ b/sshh/ViewModels/ContentViewViewModel.swift
@@ -13,10 +13,10 @@ final class ContentViewViewModel: ObservableObject {
     @Published var inputViewModels: [InputRowViewModel] = []
 
     init() {
-        refresh()
+        reload()
     }
 
-    func refresh() {
+    func reload() {
         inputViewModels = AudioDevice.allInputDevices().map {
             InputRowViewModel(device: $0)
         }

--- a/sshh/ViewModels/ContentViewViewModel.swift
+++ b/sshh/ViewModels/ContentViewViewModel.swift
@@ -9,14 +9,16 @@
 import AMCoreAudio
 import SwiftUI
 
-class ContentViewViewModel: ObservableObject {
-    @Published var inputDevices: [AudioDevice]
+final class ContentViewViewModel: ObservableObject {
+    @Published var inputViewModels: [InputRowViewModel] = []
 
     init() {
-        self.inputDevices = AudioDevice.allInputDevices()
+        refresh()
     }
 
     func refresh() {
-        self.inputDevices = AudioDevice.allInputDevices()
+        inputViewModels = AudioDevice.allInputDevices().map {
+            InputRowViewModel(device: $0)
+        }
     }
 }

--- a/sshh/ViewModels/InputRowViewModel.swift
+++ b/sshh/ViewModels/InputRowViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  InputRowViewModel.swift
+//  sshh
+//
+//  Created by Boris Bielik on 10/10/2020.
+//  Copyright © 2020 Giacomo Rebonato. All rights reserved.
+//
+
+import Foundation
+import AMCoreAudio
+
+final class InputRowViewModel: ObservableObject, Identifiable {
+
+    var id = UUID()
+    var device: AudioDevice
+    var deviceName: String {
+        device.name
+    }
+    var lastVolumeLevel: Float32 = 0
+
+    @Published var volume: Float32 = 0 {
+        didSet {
+            device.setVolume(volume, channel: 0, direction: .recording)
+        }
+    }
+
+    @Published var isMuted: Bool = false {
+        didSet {
+            self.toggleMute()
+        }
+    }
+
+    init(device: AudioDevice) {
+        let volumeInfo = device.volumeInfo(channel: 0, direction: .recording)
+
+        self.device = device
+        self.isMuted = (device.isMuted(channel: 0, direction: .recording)) ?? false
+        self.volume = volumeInfo?.volume ?? self.lastVolumeLevel
+
+        print("Volume is " + String(self.volume))
+    }
+
+    func toggleMute() {
+        let isMuted = self.device.isMuted(channel: 0, direction: .recording) ?? false
+        self.lastVolumeLevel = self.device.volumeInfo(channel: 0, direction: .recording)?.volume ?? 0
+        self.device.setMute(!isMuted, channel: 0, direction: .recording)
+    }
+
+    var isDefaultDevice: Bool {
+        AudioDevice.defaultInputDevice()?.id == self.device.id
+    }
+
+    func setDeviceAsDefault() {
+        device.setAsDefaultInputDevice()
+    }
+}

--- a/sshh/components/ContentView.swift
+++ b/sshh/components/ContentView.swift
@@ -1,4 +1,3 @@
-import AMCoreAudio
 import SwiftUI
 
 struct ContentView: View {
@@ -6,16 +5,12 @@ struct ContentView: View {
 
     var body: some View {
         VStack {
-            ForEach(vm.inputDevices, id: \.id) {
-                device in InputRow(device: device, refresh: self.vm.refresh)
+            ForEach(0..<vm.inputViewModels.count, id: \.self) { index in
+                InputRow(vm: self.$vm.inputViewModels[index])
             }
             Divider()
             HStack {
-                Button(action: {
-                    exit(0)
-                }) {
-                    Text("Quit")
-                }
+                QuitButton()
             }
         }
         .padding(.top, 12)
@@ -24,7 +19,6 @@ struct ContentView: View {
         .padding(.bottom, 4)
     }
 }
-
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {

--- a/sshh/components/ContentView.swift
+++ b/sshh/components/ContentView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 struct ContentView: View {
-    @ObservedObject var vm: ContentViewViewModel
+    @EnvironmentObject var vm: ContentViewViewModel
 
     var body: some View {
         VStack {
             ForEach(0..<vm.inputViewModels.count, id: \.self) { index in
-                InputRow(vm: self.$vm.inputViewModels[index])
+                InputRow(vm: $vm.inputViewModels[index])
             }
             Divider()
             HStack {
@@ -22,6 +22,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView(vm: ContentViewViewModel())
+        ContentView()
+            .environmentObject(ContentViewViewModel())
     }
 }

--- a/sshh/components/InputRow.swift
+++ b/sshh/components/InputRow.swift
@@ -1,75 +1,29 @@
-import AMCoreAudio
 import SwiftUI
 
-class InputRowViewModel: ObservableObject {
-    var device: AudioDevice
-    var refresh: () -> Void
-    var lastVolumeLevel: Float32 = 0
-    
-    init(device: AudioDevice, refresh: @escaping () -> Void) {
-        let volumeInfo = device.volumeInfo(channel: 0, direction: .recording)
-        
-        self.device = device
-        self.isMuted = (device.isMuted(channel: 0, direction: .recording)) ?? false
-        self.refresh = refresh
-        self.volume = volumeInfo?.volume ?? self.lastVolumeLevel
-        
-        print("Volume is " + String(self.volume))
-    }
-    
-    func toggleMute() {
-        let isMuted = self.device.isMuted(channel: 0, direction: .recording) ?? false
-        self.lastVolumeLevel = self.device.volumeInfo(channel: 0, direction: .recording)?.volume ?? 0
-        self.device.setMute(!isMuted, channel: 0, direction: .recording)
-    }
-    
-    func isDefault() -> Bool {
-        return AudioDevice.defaultInputDevice()?.id == self.device.id
-    }
-    
-    @Published var volume: Float32 = 0 {
-        didSet {
-            device.setVolume(volume, channel: 0, direction: .recording)
-        }
-    }
-    
-    @Published var isMuted: Bool = false {
-        didSet {
-            self.toggleMute()
-            self.refresh()
-        }
-    }
-}
-
 struct InputRow: View {
-    var device: AudioDevice
-    var refresh: () -> Void
-    @ObservedObject var vm: InputRowViewModel
-    
-    init(device: AudioDevice, refresh: @escaping () -> Void) {
-        self.device = device
-        self.refresh = refresh
-        vm = InputRowViewModel(device: device, refresh: refresh)
-    }
-    
+    @Binding var vm: InputRowViewModel
+
     var body: some View {
         VStack {
             HStack(alignment: .center) {
-                self.vm.isDefault() ?
-                    Text(device.name).bold() : Text(device.name)
+                if vm.isDefaultDevice {
+                    Text(vm.deviceName)
+                } else {
+                    Text(vm.deviceName)
+                        .bold()
+                }
             }
             HStack {
-                Slider(value: self.$vm.volume, in: 0...1, step: 0.1)
-                Toggle(isOn: self.$vm.isMuted) {
+                Slider(value: $vm.volume, in: 0...1, step: 0.1)
+                Toggle(isOn: $vm.isMuted) {
                     Text("Mute")
                 }
                 Button(action: {
-                    self.device.setAsDefaultInputDevice()
-                    self.refresh()
+                    vm.setDeviceAsDefault()
                 }) {
                     Text("Default")
                 }
-                .disabled(self.vm.isDefault())
+                .disabled(vm.isDefaultDevice)
             }
         }
     }

--- a/sshh/components/InputRow.swift
+++ b/sshh/components/InputRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InputRow: View {
     @Binding var vm: InputRowViewModel
+    @EnvironmentObject var content: ContentViewViewModel
 
     var body: some View {
         VStack {
@@ -19,7 +20,8 @@ struct InputRow: View {
                     Text("Mute")
                 }
                 Button(action: {
-                    vm.setDeviceAsDefault()
+                    vm.isDefaultDevice = true
+                    content.reload()
                 }) {
                     Text("Default")
                 }

--- a/sshh/components/QuitButton.swift
+++ b/sshh/components/QuitButton.swift
@@ -1,0 +1,26 @@
+//
+//  QuitButton.swift
+//  sshh
+//
+//  Created by Boris Bielik on 10/10/2020.
+//  Copyright © 2020 Giacomo Rebonato. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct QuitButton: View {
+    var body: some View {
+        Button(action: {
+            exit(0)
+        }) {
+            Text("Quit")
+        }
+    }
+}
+
+struct Quit_Button_Previews: PreviewProvider {
+    static var previews: some View {
+        QuitButton()
+    }
+}


### PR DESCRIPTION
# Description
In this PR I extracted view model and view into separate standalone files.

The functionality of the tool stays intact, though I changed the philosophy of how the changes are backpropagated to view models and respective services.

1. `InputRow` (view) no longer generates `InputRowViewModel`, this is responsibility of the `ContentViewModel`. The inputViewModels are generated on init.
2. `InputRowViewModel` is passed as binding to the `InputRow`. This allowed us to get rid of the `refresh` func, since the changes to the `viewModel` are automatically backpropagated to the `ContentViewModel`.

# Changes
* CI runs using Xcode 12.0 (latest stable version)
* QuitButton extracted into its own view
* InputRowViewModel extracted into its own class
* ContentViewModel now holds a list of input view models
* InputRow is no longer dependent on AMCoreAudio symbols, neither no longer responsible for view model generation
* small code cleanup
